### PR TITLE
RSS support 

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -21,7 +21,8 @@ return [
                 'class' => \MauticPlugin\MauticAdvancedTemplatesBundle\Helper\TemplateProcessor::class,
                 'arguments' => [
                     'monolog.logger.mautic',
-                    'mautic.plugin.advanced_templates.helper.twig_loader_dynamiccontent'
+                    'mautic.plugin.advanced_templates.helper.twig_loader_dynamiccontent',
+                    'mautic.plugin.advanced_templates.helper.feed_factory'
                 ]
             ],
             'mautic.plugin.advanced_templates.helper.twig_loader_dynamiccontent' => [
@@ -30,7 +31,20 @@ return [
                     'monolog.logger.mautic',
                     'mautic.model.factory'
                 ]
-            ]
+            ],
+            'mautic.plugin.advanced_templates.helper.feed_factory' => [
+                'class' => \MauticPlugin\MauticAdvancedTemplatesBundle\Feed\FeedFactory::class,
+                'arguments' => [
+                    'mautic.plugin.advanced_templates.helper.feed_processor'
+                ]
+            ],
+            'mautic.plugin.advanced_templates.helper.feed_processor' => [
+                'class' => \MauticPlugin\MauticAdvancedTemplatesBundle\Feed\FeedProcessor::class,
+                'arguments' => [
+                    'mautic.lead.model.lead',
+                ]
+            ],
+
         ]
     ]
 ];

--- a/EventListener/EmailSubscriber.php
+++ b/EventListener/EmailSubscriber.php
@@ -52,19 +52,6 @@ class EmailSubscriber extends CommonSubscriber
     {
         $this->logger->info('onEmailGenerate MauticAdvancedTemplatesBundle\EmailSubscriber');
         $content = $event->getContent();
-        $content .= "
-        {% TWIG_BLOCK %} 
-  {% set items = 'http://mautic.test/feed.rss' | rss('segments') %}  
-   <ul>
- {% for item in items %}
-          <li>  
-          <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
-          <br />{{ item.description|raw }}
-          </li>
-    {% endfor %}
-    </ul>
-{% END_TWIG_BLOCK %}
-        ";
         $content = $this->templateProcessor->processTemplate($content,  $event->getLead());
         $event->setContent($content);
     }

--- a/EventListener/EmailSubscriber.php
+++ b/EventListener/EmailSubscriber.php
@@ -52,6 +52,19 @@ class EmailSubscriber extends CommonSubscriber
     {
         $this->logger->info('onEmailGenerate MauticAdvancedTemplatesBundle\EmailSubscriber');
         $content = $event->getContent();
+        $content .= "
+        {% TWIG_BLOCK %} 
+  {% set items = 'http://mautic.test/feed.rss' | rss('segments') %}  
+   <ul>
+ {% for item in items %}
+          <li>  
+          <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
+          <br />{{ item.description|raw }}
+          </li>
+    {% endfor %}
+    </ul>
+{% END_TWIG_BLOCK %}
+        ";
         $content = $this->templateProcessor->processTemplate($content,  $event->getLead());
         $event->setContent($content);
     }

--- a/Feed/Feed.php
+++ b/Feed/Feed.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MauticPlugin\MauticAdvancedTemplatesBundle\Feed;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
+
+class Feed
+{
+    /** @var  string */
+    private $feed;
+
+    /** @var \SimpleXMLElement  */
+    private $rss;
+
+    public function __construct($feed)
+   {
+       $this->feed = $feed;
+       $this->rss = simplexml_load_file($feed);
+   }
+
+    /**
+     * @return \SimpleXMLElement
+     */
+    public function getItems(): \SimpleXMLElement
+    {
+        return $this->rss->channel->item;
+    }
+}

--- a/Feed/FeedFactory.php
+++ b/Feed/FeedFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace MauticPlugin\MauticAdvancedTemplatesBundle\Feed;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
+
+class FeedFactory
+{
+
+    /** @var  string */
+    private $feed;
+
+    /** @var  string|null */
+    private $type;
+
+    /**
+     * @var FeedProcessor
+     */
+    private $feedProcessor;
+
+    /**
+     * FeedFactory constructor.
+     *
+     * @param FeedProcessor $feedProcessor
+     */
+    public function __construct(FeedProcessor $feedProcessor)
+    {
+        $this->feedProcessor = $feedProcessor;
+    }
+
+    /**
+     * @param int $leadId
+     * @param array $args
+     *
+     * @return \SimpleXMLElement|void
+     */
+    public function getItems($leadId, array $args)
+    {
+        $this->feed = new Feed($args[0]);
+        $this->type = isset($args[1]) ? $args[1] : null;
+
+        switch ($this->type) {
+            case 'segments':
+                return $this->feedProcessor->getSegmentsRelatedFeedItems($leadId, $this->feed);
+                break;
+            default:
+                return $this->feed->getItems();
+                break;
+        }
+
+
+    }
+}

--- a/Feed/FeedProcessor.php
+++ b/Feed/FeedProcessor.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MauticPlugin\MauticAdvancedTemplatesBundle\Feed;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
+
+class FeedProcessor
+{
+    /**
+     * @var LeadModel
+     */
+    private $leadModel;
+
+    /**
+     * @var Lead
+     */
+    private $lead;
+
+    /**
+     * RSSProcessor constructor.
+     *
+     * @param LeadModel $leadModel
+     * @param Feed      $feed
+     */
+    public function __construct(LeadModel $leadModel)
+    {
+        $this->leadModel = $leadModel;
+
+    }
+
+    /**
+     * @param int $leadId
+     * @param Feed $feed
+     *
+     * @return \SimpleXMLElement
+     */
+    public function getSegmentsRelatedFeedItems($leadId, Feed $feed)
+    {
+        if ($this->lead = $this->leadModel->getEntity($leadId)) {
+            $contactPrefsSegmentsAliases =  array_column($this->leadModel->getLists($this->lead, true, true, true), 'alias');
+            $items = [];
+            foreach ($feed->getItems()  as $item) {
+                foreach ($item->category as $category) {
+                    if (in_array($category, $contactPrefsSegmentsAliases)) {
+                        $items[] = $item;
+                        continue 2;
+                    }
+                }
+            }
+            return $items;
+        }
+    }
+
+}

--- a/Helper/TemplateProcessor.php
+++ b/Helper/TemplateProcessor.php
@@ -77,7 +77,6 @@ class TemplateProcessor
         }));
 
         $twig->addFilter(new \Twig_SimpleFilter('rss', function () {
-            $this->lead['id'] = 22833;
             return $this->feedFactory->getItems($this->lead['id'], func_get_args());
         }));
     }

--- a/README.md
+++ b/README.md
@@ -134,28 +134,28 @@ Let's continue with the previous example but turn template for rendering a singl
 ### Example 4: RSS support
     
     
-    ```twig
-    {% TWIG_BLOCK %} 
-        {% set items = 'http://domain.tld/feed/' | rss %}     
-        <ul> 
-        {% for item in cart %}
-            <li>
-             <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
-             <br />{{ item.description|raw }}
-             </li>
-        {% endfor %}
-        </ul>             
-    {% END_TWIG_BLOCK %}
-    ```
+```twig
+     {% TWIG_BLOCK %} 
+          {% set items = 'http://domain.tld/feed/' | rss %}     
+          <ul> 
+          {% for item in items %}
+              <li>
+               <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
+               <br />{{ item.description|raw }}
+               </li>
+          {% endfor %}
+          </ul>             
+      {% END_TWIG_BLOCK %}
+```
         
     
  ### Example 5: RSS related categories to contact's segments
         
-        ```twig
+```twig
         {% TWIG_BLOCK %} 
             {% set items = 'http://domain.tld/feed/' | rss('segments') %}     
             <ul> 
-            {% for item in cart %}
+            {% for item in items %}
                 <li>
                  <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
                  <br />{{ item.description|raw }}
@@ -163,7 +163,7 @@ Let's continue with the previous example but turn template for rendering a singl
             {% endfor %}
             </ul>             
         {% END_TWIG_BLOCK %}
-        ```
+```
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ There is a high probability it is compatible with other environments, but we nev
     ```
 * Reusable TWIG snippets could be loaded form Dynamic Content entities.
 * TWIG extended with some useful functions and filters (see below).
+* RSS support
+* RSS items related to contact's segment preferences center and RSS category    
 
 ## Installation
 
@@ -128,6 +130,40 @@ Let's continue with the previous example but turn template for rendering a singl
     {% END_TWIG_BLOCK %}
     ```
     Notice prefix `dc:` which instructs template resolver to look for dynamic content instance.
+    
+### Example 4: RSS support
+    
+    
+    ```twig
+    {% TWIG_BLOCK %} 
+        {% set items = 'http://domain.tld/feed/' | rss %}     
+        <ul> 
+        {% for item in cart %}
+            <li>
+             <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
+             <br />{{ item.description|raw }}
+             </li>
+        {% endfor %}
+        </ul>             
+    {% END_TWIG_BLOCK %}
+    ```
+        
+    
+ ### Example 5: RSS related categories to contact's segments
+        
+        ```twig
+        {% TWIG_BLOCK %} 
+            {% set items = 'http://domain.tld/feed/' | rss('segments') %}     
+            <ul> 
+            {% for item in cart %}
+                <li>
+                 <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
+                 <br />{{ item.description|raw }}
+                 </li>
+            {% endfor %}
+            </ul>             
+        {% END_TWIG_BLOCK %}
+        ```
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ Let's continue with the previous example but turn template for rendering a singl
     ```
     Notice prefix `dc:` which instructs template resolver to look for dynamic content instance.
     
-### Example 4: RSS support
-    
+### Example 4: RSS support    
     
 ```twig
      {% TWIG_BLOCK %} 
@@ -149,7 +148,12 @@ Let's continue with the previous example but turn template for rendering a singl
 ```
         
     
- ### Example 5: RSS related categories to contact's segments
+ ### Example 5: RSS related items to contact's segments
+
+- Add one or more categories to item 
+https://www.w3schools.com/xml/rss_tag_category_item.asp 
+- Each contact receive personalized items based on segment assignemnt.
+- Matching between item categories and segment aliases
         
 ```twig
         {% TWIG_BLOCK %} 


### PR DESCRIPTION
This PR added support for rss and rss related based on categories and contact segments.

This PR we're using on production

#### RSS support    
    
```twig
     {% TWIG_BLOCK %} 
          {% set items = 'http://domain.tld/feed/' | rss %}     
          <ul> 
          {% for item in items %}
              <li>
               <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
               <br />{{ item.description|raw }}
               </li>
          {% endfor %}
          </ul>             
      {% END_TWIG_BLOCK %}
```
        
    
#### RSS related items to contact's segments

- Add one or more categories to item 
https://www.w3schools.com/xml/rss_tag_category_item.asp 
- Each contact receive personalized items based on segment assignemnt.
- Matching between item categories and segment aliases
        
```twig
        {% TWIG_BLOCK %} 
            {% set items = 'http://domain.tld/feed/' | rss('segments') %}     
            <ul> 
            {% for item in items %}
                <li>
                 <a href=''{{ item.link }}'>{{ item.title }}</a> ({{ item.pubDate|date('m/d/Y') }})
                 <br />{{ item.description|raw }}
                 </li>
            {% endfor %}
            </ul>             
        {% END_TWIG_BLOCK %}
```
