### PR TITLE
Share email tokens with template, rather than only Lead

### DIFF
--- a/EventListener/EmailSubscriber.php
+++ b/EventListener/EmailSubscriber.php
@@ -1,14 +1,11 @@
 <?php
 
 namespace MauticPlugin\MauticAdvancedTemplatesBundle\EventListener;
-use Mautic\CampaignBundle\Entity\Lead;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event as Events;
 use Mautic\EmailBundle\Helper\PlainTextHelper;
-use Mautic\CoreBundle\Exception as MauticException;
 use MauticPlugin\MauticAdvancedTemplatesBundle\Helper\TemplateProcessor;
-use Psr\Log\LoggerInterface;
 
 /**
  * Class EmailSubscriber.
@@ -61,10 +58,10 @@ class EmailSubscriber extends CommonSubscriber
             $content = $event->getContent();
         }
 
-        $subject = $this->templateProcessor->processTemplate($subject,  $event->getLead());
+        $subject = $this->templateProcessor->processTemplate($subject,  $event);
         $event->setSubject($subject);
 
-        $content = $this->templateProcessor->processTemplate($content,  $event->getLead());
+        $content = $this->templateProcessor->processTemplate($content,  $event);
         $event->setContent($content);
 
 


### PR DESCRIPTION
Hi there,

We are using Mautic in use cases usually different than mainstream, such as for our transactional emails as a microservice. This requires us to share tokens that are sent from our message bus into our emails. Only `Lead` object wasn't enough, so instead, I am now sharing the `SendEmailEvent` with the template processor. The code is aware of its parent, `CommonEvent` as well.

This change would not affect anyone using it, but it would enable flexibility if event tokens are used in a custom workflow.